### PR TITLE
Add debug logging for GUI startup and processing

### DIFF
--- a/app/controllers/app_controller.py
+++ b/app/controllers/app_controller.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from pathlib import Path
+import logging
 from PyQt5 import QtCore
 
 class _ProcessTask(QtCore.QRunnable):
@@ -13,10 +14,16 @@ class _ProcessTask(QtCore.QRunnable):
 
     def run(self):
         try:
+            logging.debug("Processing started: %s", self.image_path)
             # лениво импортируем только в рабочем потоке
             from core.service import CoreService
             svc = CoreService(self.det1_path, self.det2_path, device='cpu')  # CPU во избежание CUDA-конфликтов
             res = svc.process(Path(self.image_path))
+            logging.debug(
+                "Processing finished: overlay=%s csv=%s",
+                res["overlay_path"],
+                res["csv_path"],
+            )
             # вернуть результат в GUI-поток
             QtCore.QMetaObject.invokeMethod(
                 self.done_sig, "emit", QtCore.Qt.QueuedConnection, QtCore.Q_ARG(str, str(res["overlay_path"]))
@@ -25,6 +32,7 @@ class _ProcessTask(QtCore.QRunnable):
                 self.status_sig, "emit", QtCore.Qt.QueuedConnection, QtCore.Q_ARG(str, f"Готово: {res['csv_path']}")
             )
         except Exception as e:
+            logging.exception("Processing failed")
             QtCore.QMetaObject.invokeMethod(
                 self.status_sig, "emit", QtCore.Qt.QueuedConnection, QtCore.Q_ARG(str, f"Ошибка: {e}")
             )
@@ -48,6 +56,7 @@ class AppController(QtCore.QObject):
 
     @QtCore.pyqtSlot(str)
     def process_image(self, image_path: str):
+        logging.debug("Queue image for processing: %s", image_path)
         self.sig_status.emit("Обработка запущена…")
         task = _ProcessTask(self.det1_path, self.det2_path, image_path, self.sig_overlay_ready, self.sig_status)
         self.pool.start(task)

--- a/app/debug_utils.py
+++ b/app/debug_utils.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+import logging
+import faulthandler
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def setup_debug_logging(log_path: Optional[str] = None) -> Path:
+    """Configure debug logging and crash reports.
+
+    Parameters
+    ----------
+    log_path:
+        Optional path to log file. If not provided, ``saplings_debug.log``
+        will be created in the current working directory.
+
+    Returns
+    -------
+    Path
+        Path to the log file used.
+    """
+    log_file = Path(log_path or "saplings_debug.log")
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # открываем файл и включаем faulthandler для захвата нативных падений
+    fh = open(log_file, "a", encoding="utf-8")
+    faulthandler.enable(fh)
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        filename=str(log_file),
+        filemode="a",
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    def _excepthook(exc_type, exc, tb):
+        logging.exception("Uncaught exception", exc_info=(exc_type, exc, tb))
+
+    # перехватываем необработанные исключения
+    sys.excepthook = _excepthook
+
+    # выводим дополнительные сообщения Qt о загрузке плагинов
+    os.environ.setdefault("QT_DEBUG_PLUGINS", "1")
+
+    logging.debug("Debug logging initialized")
+    return log_file

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,10 @@ from PyQt5 import QtWidgets
 from PyQt5.QtWidgets import QMainWindow, QSplitter
 # НЕ импортируем torch/ultralytics нигде здесь
 
+# Вспомогательные отладочные инструменты
+from app.debug_utils import setup_debug_logging
+import logging
+
 # UI-виджеты
 from app.widgets.image_viewer import ImageViewer
 from app.widgets.left_tool_panel import LeftToolPanel
@@ -73,6 +77,10 @@ class MainWindow(QMainWindow):
 
 
 def main():
+    # включаем отладочное логирование и обработчик аварий
+    log_file = setup_debug_logging()
+    logging.debug("GUI starting; log file: %s", log_file)
+
     app = QtWidgets.QApplication(sys.argv)
 
     # ВАЖНО: временно без qt-material (может быть причиной падения)


### PR DESCRIPTION
## Summary
- add reusable debug utilities to log crashes and Qt plugin info
- hook debug logging into application startup
- trace controller workflow when processing images

## Testing
- `python -m py_compile app/main.py app/controllers/app_controller.py app/debug_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a47e8b2eb08323a980d2f46f8a9730