### PR TITLE
fix: safer image loading and GUI dialog handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import sys
 from pathlib import Path
-from PyQt5 import QtWidgets
+from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtWidgets import QMainWindow, QSplitter
 # НЕ импортируем torch/ultralytics нигде здесь
 
@@ -42,6 +42,7 @@ class MainWindow(QMainWindow):
 
         # wiring
         self._current_path = ''
+        self._dlg_opening = False
         self.left.sig_open.connect(self._dialog_open)
         self.left.sig_process.connect(self._process)
         self.right.sig_file_selected.connect(self._open)
@@ -53,12 +54,29 @@ class MainWindow(QMainWindow):
         # self.viewer.sig_click.connect(self._on_view_click)
 
     def _dialog_open(self):
-        p, _ = QtWidgets.QFileDialog.getOpenFileName(
-            self, 'Открыть', str(Path.home()),
-            'Images (*.png *.jpg *.jpeg *.tif *.tiff)'
+        if self._dlg_opening:
+            return
+        self._dlg_opening = True
+        QtCore.QMetaObject.invokeMethod(
+            self, "_dialog_open_impl", QtCore.Qt.QueuedConnection
         )
-        if p:
-            self._open(Path(p))
+
+    @QtCore.pyqtSlot()
+    def _dialog_open_impl(self):
+        try:
+            options = QtWidgets.QFileDialog.Options()
+            options |= QtWidgets.QFileDialog.DontUseNativeDialog
+            p, _ = QtWidgets.QFileDialog.getOpenFileName(
+                self,
+                'Открыть',
+                str(Path.home()),
+                'Images (*.png *.jpg *.jpeg *.tif *.tiff)',
+                options=options,
+            )
+            if p:
+                self._open(Path(p))
+        finally:
+            self._dlg_opening = False
 
     def _open(self, path: Path):
         self.viewer.load_image(path)

--- a/app/widgets/image_viewer.py
+++ b/app/widgets/image_viewer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from pathlib import Path
+import logging
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 
@@ -41,16 +42,22 @@ class ImageViewer(QtWidgets.QGraphicsView):
             h, w, ch = rgb.shape
             img = QtGui.QImage(rgb.data, w, h, ch * w, QtGui.QImage.Format_RGB888)
         pix = QtGui.QPixmap.fromImage(img)
+        if pix.isNull():
+            logging.error("Не удалось загрузить изображение: %s", path)
+            return
         self._scene.clear()
         self._pixmap_item = self._scene.addPixmap(pix)
-        self._scene.setSceneRect(pix.rect())
+        self._scene.setSceneRect(QtCore.QRectF(pix.rect()))
         self.resetTransform()
         self.fitInView(self._pixmap_item, QtCore.Qt.KeepAspectRatio)
 
     def set_pixmap(self, pixmap: QtGui.QPixmap):
+        if pixmap.isNull():
+            logging.error("Пустой QPixmap передан в set_pixmap")
+            return
         self._scene.clear()
         self._pixmap_item = self._scene.addPixmap(pixmap)
-        self._scene.setSceneRect(pixmap.rect())
+        self._scene.setSceneRect(QtCore.QRectF(pixmap.rect()))
         self.resetTransform()
         self.fitInView(self._pixmap_item, QtCore.Qt.KeepAspectRatio)
 


### PR DESCRIPTION
## Summary
- convert scene rects to `QRectF` and guard against null pixmaps
- invoke file dialog in GUI thread with reentrancy guard and non-native dialog

## Testing
- `python -m py_compile app/widgets/image_viewer.py app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a568d673448323a05dbef2d3a14dcc