### PR TITLE
feat: add layer tree panel and dark theme

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import sys
 from pathlib import Path
-from PyQt5 import QtCore, QtWidgets
+from PyQt5 import QtCore, QtWidgets, QtGui
 from PyQt5.QtWidgets import QMainWindow, QSplitter
 # НЕ импортируем torch/ultralytics нигде здесь
 
@@ -46,6 +46,7 @@ class MainWindow(QMainWindow):
         self.left.sig_open.connect(self._dialog_open)
         self.left.sig_process.connect(self._process)
         self.right.sig_file_selected.connect(self._open)
+        self.right.sig_file_closed.connect(self._on_file_closed)
         self.ctrl.sig_overlay_ready.connect(self._show_overlay)
         self.ctrl.sig_status.connect(self.statusBar().showMessage)
 
@@ -81,6 +82,7 @@ class MainWindow(QMainWindow):
     def _open(self, path: Path):
         self.viewer.load_image(path)
         self._current_path = str(path)
+        self.right.add_file(path)
         self.statusBar().showMessage(f"Открыт файл: {path}")
 
     def _process(self):
@@ -93,6 +95,12 @@ class MainWindow(QMainWindow):
         from PyQt5.QtGui import QPixmap
         self.viewer.set_pixmap(QPixmap(overlay_path))
 
+    def _on_file_closed(self, path: Path):
+        if self._current_path == str(path):
+            self.viewer.clear()
+            self._current_path = ''
+            self.statusBar().showMessage("Файл закрыт")
+
 
 def main():
     # включаем отладочное логирование и обработчик аварий
@@ -100,6 +108,21 @@ def main():
     logging.debug("GUI starting; log file: %s", log_file)
 
     app = QtWidgets.QApplication(sys.argv)
+    app.setStyle("Fusion")
+    palette = QtGui.QPalette()
+    palette.setColor(QtGui.QPalette.Window, QtGui.QColor(53, 53, 53))
+    palette.setColor(QtGui.QPalette.WindowText, QtCore.Qt.white)
+    palette.setColor(QtGui.QPalette.Base, QtGui.QColor(25, 25, 25))
+    palette.setColor(QtGui.QPalette.AlternateBase, QtGui.QColor(53, 53, 53))
+    palette.setColor(QtGui.QPalette.ToolTipBase, QtCore.Qt.white)
+    palette.setColor(QtGui.QPalette.ToolTipText, QtCore.Qt.white)
+    palette.setColor(QtGui.QPalette.Text, QtCore.Qt.white)
+    palette.setColor(QtGui.QPalette.Button, QtGui.QColor(53, 53, 53))
+    palette.setColor(QtGui.QPalette.ButtonText, QtCore.Qt.white)
+    palette.setColor(QtGui.QPalette.BrightText, QtCore.Qt.red)
+    palette.setColor(QtGui.QPalette.Highlight, QtGui.QColor(142, 45, 197).lighter())
+    palette.setColor(QtGui.QPalette.HighlightedText, QtCore.Qt.black)
+    app.setPalette(palette)
 
     # ВАЖНО: временно без qt-material (может быть причиной падения)
     # try:

--- a/app/widgets/image_viewer.py
+++ b/app/widgets/image_viewer.py
@@ -61,6 +61,11 @@ class ImageViewer(QtWidgets.QGraphicsView):
         self.resetTransform()
         self.fitInView(self._pixmap_item, QtCore.Qt.KeepAspectRatio)
 
+    def clear(self):
+        """Очистить сцену от изображения."""
+        self._scene.clear()
+        self._pixmap_item = None
+
     # колесо мыши — зум
     def wheelEvent(self, event: QtGui.QWheelEvent):
         if event.angleDelta().y() == 0:

--- a/app/widgets/right_explorer.py
+++ b/app/widgets/right_explorer.py
@@ -1,42 +1,89 @@
 from __future__ import annotations
+
 from pathlib import Path
+from typing import Dict
+
 from PyQt5 import QtCore, QtWidgets
 
 
 class RightExplorer(QtWidgets.QWidget):
-    """
-    Правая панель: проводник файлов.
-    Показывает дерево, сигналит выбранный файл.
-    """
-    sig_file_selected = QtCore.pyqtSignal(object)  # Path
+    """Правая панель: список открытых изображений."""
 
-    def __init__(self, root_path: Path | None = None, parent=None):
+    sig_file_selected = QtCore.pyqtSignal(object)  # Path
+    sig_file_closed = QtCore.pyqtSignal(object)  # Path
+
+    def __init__(self, parent=None):
         super().__init__(parent)
         self.setMinimumWidth(260)
         layout = QtWidgets.QVBoxLayout(self)
 
-        self.model = QtWidgets.QFileSystemModel(self)
-        self.model.setRootPath(str(root_path or Path.home()))
-        self.model.setNameFilters(["*.png", "*.jpg", "*.jpeg", "*.tif", "*.tiff"])
-        self.model.setNameFilterDisables(False)
+        self.tree = QtWidgets.QTreeWidget(self)
+        self.tree.setColumnCount(3)
+        self.tree.setHeaderLabels(["ID", "Название", ""])
+        header = self.tree.header()
+        header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(1, QtWidgets.QHeaderView.Stretch)
+        header.setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeToContents)
+        self.tree.setAlternatingRowColors(True)
+        self.tree.setStyleSheet(
+            "QTreeWidget {background-color:#2b2b2b;color:#f0f0f0;}"
+            "QHeaderView::section {background-color:#333;color:#f0f0f0;}"
+        )
 
-        self.view = QtWidgets.QTreeView(self)
-        self.view.setModel(self.model)
-        self.view.setRootIndex(self.model.index(str(root_path or Path.home())))
-        self.view.setColumnWidth(0, 220)
-        for c in range(1, 4):  # спрячем лишние столбцы
-            self.view.setColumnHidden(c, True)
+        layout.addWidget(self.tree)
 
-        layout.addWidget(self.view)
+        self._items: Dict[Path, QtWidgets.QTreeWidgetItem] = {}
+        self.tree.itemSelectionChanged.connect(self._on_sel)
 
-        self.view.selectionModel().selectionChanged.connect(self._on_sel)
-
-    def _on_sel(self, *_):
-        idxs = self.view.selectionModel().selectedIndexes()
-        if not idxs:
+    # ------------------------------------------------------------------
+    def add_file(self, path: Path):
+        """Добавить файл в дерево."""
+        if path in self._items:
+            self.tree.setCurrentItem(self._items[path])
             return
-        idx = idxs[0]
-        path = Path(self.model.filePath(idx))
-        # отдаём только файлы картинок
-        if path.is_file() and path.suffix.lower() in {".png", ".jpg", ".jpeg", ".tif", ".tiff"}:
-            self.sig_file_selected.emit(path)
+
+        row_id = self.tree.topLevelItemCount() + 1
+        item = QtWidgets.QTreeWidgetItem([str(row_id), path.name])
+        self.tree.addTopLevelItem(item)
+
+        btn = QtWidgets.QToolButton()
+        btn.setIcon(self.style().standardIcon(QtWidgets.QStyle.SP_TitleBarCloseButton))
+        btn.setAutoRaise(True)
+        btn.clicked.connect(lambda _, i=item: self._remove_item(i))
+        self.tree.setItemWidget(item, 2, btn)
+
+        self._items[path] = item
+        self.tree.setCurrentItem(item)
+
+    # ------------------------------------------------------------------
+    def _on_sel(self):
+        items = self.tree.selectedItems()
+        if not items:
+            return
+        item = items[0]
+        for path, it in self._items.items():
+            if it is item:
+                self.sig_file_selected.emit(path)
+                break
+
+    # ------------------------------------------------------------------
+    def _remove_item(self, item: QtWidgets.QTreeWidgetItem):
+        path = None
+        for p, it in list(self._items.items()):
+            if it is item:
+                path = p
+                del self._items[p]
+                break
+        if path is None:
+            return
+        idx = self.tree.indexOfTopLevelItem(item)
+        self.tree.takeTopLevelItem(idx)
+        self._renumber()
+        self.sig_file_closed.emit(path)
+
+    # ------------------------------------------------------------------
+    def _renumber(self):
+        for i in range(self.tree.topLevelItemCount()):
+            it = self.tree.topLevelItem(i)
+            it.setText(0, str(i + 1))
+


### PR DESCRIPTION
## Summary
- replace file explorer with layer tree listing opened images with IDs and close buttons
- add dark Fusion palette for better visuals
- allow clearing current image when closed

## Testing
- `python -m pytest`
- `python -m py_compile app/widgets/right_explorer.py app/widgets/image_viewer.py app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a56ef5b0f08323ba2eb7f1ad782f7a